### PR TITLE
add comments post function and make two databases from a container

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,4 @@ Hc/RailsSpecificActionName:
 RSpec/ExampleLength:
   Exclude:
     - spec/requests/api/v1/tweets_spec.rb
+    - spec/requests/api/v1/comments_spec.rb

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CommentsController < ApplicationController
+      before_action :set_tweets, only: %i[create]
+
+      def create
+        @comment = @tweet.comments.new(comment_params)
+        @comment.user = current_api_v1_user
+        # binding.pry
+        if @comment.save
+          render json: { status: 'SUCCESS', message: 'Comment successfully saved', data: { comment: @comment } }
+        else
+          render json: { status: 'ERROR', message: 'Comment not saved' }
+        end
+      end
+
+      private
+
+      def set_tweets
+        @tweet = Tweet.find(params[:tweet_id])
+      end
+
+      def comment_params
+        params.require(:comment).permit(:tweet_id, :content)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -13,7 +13,7 @@ module Api
         @tweets = Tweet.all.order(created_at: 'DESC').limit(limit_params).offset(offset_params)
         # 投稿データに付随してユーザーデータを取得、画像取得に必要なメソッドも追加で指定
         render json: { status: 'SUCCESS', message: 'Have gotten all tweets', data: { tweets: @tweets, count: Tweet.all.count } },
-               include: { user: { methods: %i[header_urls icon_urls], include: :tweets } }
+               include: [{ user: { methods: %i[header_urls icon_urls], include: :tweets } }, :comments]
       end
 
       def show

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :tweet
+  validates :content, presence: true, length: { in: 1..116 }
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -6,6 +6,7 @@ class Tweet < ApplicationRecord
   belongs_to :user
   validates :content, presence: true, length: { in: 1..140 }
   has_many_attached :images
+  has_many :comments, dependent: :destroy
 
   # オブジェクトをJSON形式に変換する際の出力内容をカスタマイズする。通常の属性(idやname)に加えてimage_urlsメソッドの返り値も含める
   def as_json(options = {})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable, :omniauthable, omniauth_providers: [:google_oauth2]
   has_many :tweets, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_one_attached :icon
   has_one_attached :header
   validates :phone_number, presence: true

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,12 +8,11 @@ default: &default
 
 development:
   <<: *default
-  database: myapp_development
+  database: dev # postgresで生成したデータベース名
 
 test:
   <<: *default
-  database: myapp_test
-  host: test-db
+  database: test # postgresで生成したデータベース名
 
 production:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       resources :tweets, only: %i[create index show destroy]
       resources :images, only: %i[create]
       resources :users, only: %i[show]
+      resources :comments, only: %i[create]
     end
   end
 end

--- a/db/migrate/20250826104510_create_comments.rb
+++ b/db/migrate/20250826104510_create_comments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.string :content, limit: 116, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :tweet, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_03_124429) do
+ActiveRecord::Schema[7.0].define(version: 2025_08_26_104510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_03_124429) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.string "content", limit: 116, null: false
+    t.bigint "user_id", null: false
+    t.bigint "tweet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tweet_id"], name: "index_comments_on_tweet_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -88,5 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_03_124429) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "tweets"
+  add_foreign_key "comments", "users"
   add_foreign_key "tweets", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,15 @@ version: "3"
 services:
   db:
     image: postgres:14.6
+    container_name: postgres_multi_db
     environment:
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_MULTIPLE_DATABASES: dev, test # 一つのコンテナにdevとtest２つのデータベースを作成
     volumes:
+      - ./init-multiple-databases.sh:/docker-entrypoint-initdb.d/init-multiple-databases.sh
       - db:/var/lib/postgresql/data
-  test-db:
-    image: postgres:14.6
-    environment:
-      POSTGRES_PASSWORD: password
-    volumes:
-      - test-db:/var/lib/postgresql/data
+    restart: unless-stopped
   api:
     build: .
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
@@ -27,4 +26,4 @@ services:
 volumes:
   bundle:
   db:
-  test-db:
+  # test-db:

--- a/init-multiple-databases.sh
+++ b/init-multiple-databases.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function create_user_and_database() {
+  local database=$1
+  echo "  Creating user and database '$database'"
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "postgres" <<-EOSQL
+        CREATE USER $database;
+        CREATE DATABASE $database;
+        GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+}
+
+if [ -n "${POSTGRES_MULTIPLE_DATABASES:-}" ]; then
+  echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+  for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+    create_user_and_database $db
+  done
+  echo "Multiple databases created"
+fi

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Comment do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pry'
+
+RSpec.describe 'Api::V1::Comments' do
+  describe 'api/v1/comments' do
+    let(:user_a) { create(:user, name: 'ユーザーA', email: 'a@sample.com', password: 'password', confirmed_at: Time.zone.today) }
+
+    it 'コメントを作成する' do
+      auth_tokens = sign_in(user_a)
+      # createはFactoryBot.createの略
+      tweet = create(:tweet, content: 'Aのタスク', user: user_a)
+
+      valid_params = { content: 'お試しコメント' }
+
+      # 新しくコメントしてデータの総数が1個増えているか確認する
+      expect do
+        post '/api/v1/comments', params: { comment: valid_params, tweet_id: tweet.id }, headers: auth_tokens
+      end.to change(Comment, :count).by(+1)
+
+      # リクエスト成功を表す200が返却された確認する
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## 課題のリンク

* http://localhost:5173/

## やったこと

* コメント投稿機能の追加
* postgresqlのコンテナ一つからデータベースを二つ生成するように修正

## 動作確認方法

* ログイン後、投稿データのコメントアイコンを左クリックしてコメントモーダルを起動し、コメントを打ち込んで投稿

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
