### PR TITLE
add comment index function

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -5,6 +5,12 @@ module Api
     class CommentsController < ApplicationController
       before_action :set_tweets, only: %i[create]
 
+      def index
+        @tweet = Tweet.find(params[:id])
+        render json: { status: 'SUCCESS', message: 'Have gotten all comments', data: { comments: @tweet.comments } },
+               include: { user: { methods: %i[header_urls icon_urls] } }
+      end
+
       def create
         @comment = @tweet.comments.new(comment_params)
         @comment.user = current_api_v1_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get 'login_users' => 'login_users#show'
       put 'login_users' => 'login_users#update'
+      get 'tweets/:id/comments' => 'comments#index'
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/registrations',
         omniauth_callbacks: 'api/v1/omniauth_callbacks'

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment do
+    content { '試しにコメント' }
+    user
+    tweet
+  end
+end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -22,5 +22,25 @@ RSpec.describe 'Api::V1::Comments' do
       # リクエスト成功を表す200が返却された確認する
       expect(response).to have_http_status(:ok)
     end
+
+    it 'コメントを全権取得する' do
+      auth_tokens = sign_in(user_a)
+      # createはFactoryBot.createの略
+      tweet = create(:tweet, content: 'Aのタスク', user: user_a)
+      create(:comment, content: 'コメントA', user: user_a, tweet:)
+      create(:comment, content: 'コメントB', user: user_a, tweet:)
+      create(:comment, content: 'コメントC', user: user_a, tweet:)
+
+      get "/api/v1/tweets/#{tweet.id}/comments", headers: auth_tokens
+
+      # status, messageは不要なので、commentsだけ指定して取得する
+      json = response.parsed_body['data']['comments']
+
+      # 作成された投稿データの数が正しく取得できたかどうかを確認する
+      expect(json.length).to eq(3)
+
+      # リクエスト成功を表す200が返却された確認する
+      expect(response).to have_http_status(:success)
+    end
   end
 end


### PR DESCRIPTION
## 課題のリンク

* http://localhost:5173/

## やったこと

* ツイート詳細画面でコメントの一覧を閲覧できるように実装


## 動作確認方法

* ログイン後、ツイート一覧画面からツイートをクリックして、詳細画面へ遷移すればコメントの一覧が表示される

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
